### PR TITLE
CMakeLists: set CMAKE_POSITION_INDEPENDENT_CODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (iac)
 message(STATUS "start build iac")
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3") 
+SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 
 


### PR DESCRIPTION
this is always set since only a shared library is being built currently;
it will affect targets other than SHARD or MODULE.

https://cmake.org/cmake/help/latest/prop_tgt/POSITION_INDEPENDENT_CODE.html#prop_tgt:POSITION_INDEPENDENT_CODE
